### PR TITLE
dev/v2.0/unit+failure

### DIFF
--- a/src/core-taggeds-failure/Failure.Tests/AssertHelper/AssertHelper.cs
+++ b/src/core-taggeds-failure/Failure.Tests/AssertHelper/AssertHelper.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Xunit;
+﻿using Xunit;
 
 namespace PrimeFuncPack.Core.Tests;
 

--- a/src/core-taggeds-failure/Failure.Tests/Failure.Tests.csproj
+++ b/src/core-taggeds-failure/Failure.Tests/Failure.Tests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="PrimeFuncPack.UnitTest.Data" Version="2.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core-taggeds-failure/Failure.Tests/Stubs/SomeFailureCode.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Stubs/SomeFailureCode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace PrimeFuncPack.Core.Tests;
 
 public enum SomeFailureCode

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Deconstruct.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Deconstruct.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.Core.Tests.AssertHelper;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Equality.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Equality.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using PrimeFuncPack.UnitTest;
 using Xunit;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Inequality.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Inequality.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using PrimeFuncPack.UnitTest;
 using Xunit;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Object.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Object.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Other.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Other.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using PrimeFuncPack.UnitTest;
 using Xunit;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Static.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Equals.Static.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Factory.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.Factory.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.Core.Tests.AssertHelper;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.GetHashCode.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.GetHashCode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.MapFailureCode.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.MapFailureCode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.Core.Tests.AssertHelper;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.ToString.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.ToString.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Globalization;
 using Xunit;

--- a/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.Failure/FailureTest.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace PrimeFuncPack.Core.Tests;
 
 public sealed partial class FailureTest

--- a/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Equals.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Equals.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Factory.Unit.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Factory.Unit.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.Core.Tests.AssertHelper;

--- a/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Factory.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.Factory.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Xunit;
 using static PrimeFuncPack.Core.Tests.AssertHelper;

--- a/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.cs
+++ b/src/core-taggeds-failure/Failure.Tests/Test.FailureStatic/FailureStaticTest.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace PrimeFuncPack.Core.Tests;
 
 public sealed partial class FailureStaticTest

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Deconstruct.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Deconstruct.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 partial struct Failure<TFailureCode>

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
@@ -8,7 +8,7 @@ partial struct Failure<TFailureCode>
         =>
         typeof(Failure<TFailureCode>);
 
-    private static IEqualityComparer<TFailureCode> FailureCodeComparer
+    private static EqualityComparer<TFailureCode> FailureCodeComparer
         =>
         EqualityComparer<TFailureCode>.Default;
 

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Common.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Equals.Impl.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Equals.Impl.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 partial struct Failure<TFailureCode>

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Equals.Wrap.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.Equals.Wrap.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.GetHashCode.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.Equality.GetHashCode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 partial struct Failure<TFailureCode>

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.InnerOrNullIfEmpty.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.InnerOrNullIfEmpty.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Runtime.CompilerServices;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.MapFailureCode.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.MapFailureCode.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 partial struct Failure<TFailureCode>

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.ToString.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.ToString.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using static System.FormattableString;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure.T/Failure.T.cs
+++ b/src/core-taggeds-failure/Failure/Failure.T/Failure.T.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure/Failure.Equals.cs
+++ b/src/core-taggeds-failure/Failure/Failure/Failure.Equals.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 partial class Failure

--- a/src/core-taggeds-failure/Failure/Failure/Failure.Factory.Unit.cs
+++ b/src/core-taggeds-failure/Failure/Failure/Failure.Factory.Unit.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure/Failure.Factory.cs
+++ b/src/core-taggeds-failure/Failure/Failure/Failure.Factory.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace System;

--- a/src/core-taggeds-failure/Failure/Failure/Failure.cs
+++ b/src/core-taggeds-failure/Failure/Failure/Failure.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace System;
 
 public static partial class Failure

--- a/src/core-unit/Unit.Tests/Unit.Tests.csproj
+++ b/src/core-unit/Unit.Tests/Unit.Tests.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="PrimeFuncPack.UnitTest.Data" Version="2.0.6" />
     <PackageReference Include="PrimeFuncPack.UnitTest.Moq" Version="1.0.3" />
   </ItemGroup>

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/InvokeThenToUnitAsync.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeAsyncTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/InvokeThenToUnit.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/InvokeThenToUnitValueAsync.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsInvokeValueAsyncTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitExtensionsTests/UnitExtensionsTests.ToUnit.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsTests/UnitExtensionsTests.ToUnit.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;

--- a/src/core-unit/Unit.Tests/UnitExtensionsTests/UnitExtensionsTests.cs
+++ b/src/core-unit/Unit.Tests/UnitExtensionsTests/UnitExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace PrimeFuncPack.Core.Tests;
+﻿namespace PrimeFuncPack.Core.Tests;
 
 public sealed partial class UnitExtensionsTests
 {

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/InvokeAsync.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeAsyncTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Invoke.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.00.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.00.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest.Moq;
 using System;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.01.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.01.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.02.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.02.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.03.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.03.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.04.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.04.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.05.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.05.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.06.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.06.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.07.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.07.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.08.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.08.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.09.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.09.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.10.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.10.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.11.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.11.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.12.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.12.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.13.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.13.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.14.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.14.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.15.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.15.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.16.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/InvokeValueAsync.16.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using PrimeFuncPack.UnitTest;
 using PrimeFuncPack.UnitTest.Moq;

--- a/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/Tests.cs
+++ b/src/core-unit/Unit.Tests/UnitInvokeValueAsyncTests/Tests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using PrimeFuncPack.UnitTest;
+﻿using PrimeFuncPack.UnitTest;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitTests/UnitTests.Equality.cs
+++ b/src/core-unit/Unit.Tests/UnitTests/UnitTests.Equality.cs
@@ -1,7 +1,4 @@
-﻿
-#nullable enable
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitTests/UnitTests.Factory.cs
+++ b/src/core-unit/Unit.Tests/UnitTests/UnitTests.Factory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitTests/UnitTests.From.cs
+++ b/src/core-unit/Unit.Tests/UnitTests/UnitTests.From.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using static PrimeFuncPack.UnitTest.TestData;
 

--- a/src/core-unit/Unit.Tests/UnitTests/UnitTests.ToString.cs
+++ b/src/core-unit/Unit.Tests/UnitTests/UnitTests.ToString.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace PrimeFuncPack.Core.Tests;

--- a/src/core-unit/Unit.Tests/UnitTests/UnitTests.cs
+++ b/src/core-unit/Unit.Tests/UnitTests/UnitTests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace PrimeFuncPack.Core.Tests;
+﻿namespace PrimeFuncPack.Core.Tests;
 
 public sealed partial class UnitTests
 {

--- a/src/core-unit/Unit/Unit.Extensions/Extensions.cs
+++ b/src/core-unit/Unit/Unit.Extensions/Extensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace System;
+﻿namespace System;
 
 public static partial class UnitExtensions
 {

--- a/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnit.cs
+++ b/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnit.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace System;
+﻿namespace System;
 
 partial class UnitExtensions
 {

--- a/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnitAsync.cs
+++ b/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnitAsync.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnitValueAsync.cs
+++ b/src/core-unit/Unit/Unit.Extensions/InvokeThenToUnitValueAsync.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit.Extensions/ToUnit.cs
+++ b/src/core-unit/Unit/Unit.Extensions/ToUnit.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit/Unit.Equality.cs
+++ b/src/core-unit/Unit/Unit/Unit.Equality.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit/Unit.Factory.cs
+++ b/src/core-unit/Unit/Unit/Unit.Factory.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit/Unit.Invoke.cs
+++ b/src/core-unit/Unit/Unit/Unit.Invoke.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace System;
+﻿namespace System;
 
 partial struct Unit
 {

--- a/src/core-unit/Unit/Unit/Unit.InvokeAsync.cs
+++ b/src/core-unit/Unit/Unit/Unit.InvokeAsync.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit/Unit.InvokeValueAsync.cs
+++ b/src/core-unit/Unit/Unit/Unit.InvokeValueAsync.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace System;
 

--- a/src/core-unit/Unit/Unit/Unit.ToString.cs
+++ b/src/core-unit/Unit/Unit/Unit.ToString.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace System;
+﻿namespace System;
 
 partial struct Unit
 {

--- a/src/core-unit/Unit/Unit/Unit.cs
+++ b/src/core-unit/Unit/Unit/Unit.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace System;
+﻿namespace System;
 
 public readonly partial struct Unit : IEquatable<Unit>
 {


### PR DESCRIPTION
Unit / Failure:
- [Target to .NET 6.0] Remove redundant `#nullable enable` directive from all the sources
- Update the tests dependencies

Failure:
- Adjust internal equality implementation